### PR TITLE
add lychee link check to housekeeper

### DIFF
--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -1,0 +1,25 @@
+name: housekeeping
+on:
+  # Run daily at 7:00
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+# pin the github actions to specific release versions
+jobs:
+  link_checker:
+    name: link checker
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout project
+        uses: actions/checkout@v3.5.2
+
+      - name: check links
+        uses: lycheeverse/lychee-action@v1.8.0
+        with:
+        with:
+          args: --verbose --no-progress '*.md' '**/*.md'
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+# ignore false positives from the link checker housekeeper
+

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Move to the _security-frontend_ module and start the frontend module with live r
 
 ## License
 
-This project is distributed under the Apache license, Version 2.0: http://www.apache.org/licenses/LICENSE-2.
+This project is distributed under the Apache license, [Version 2.0][license].
 
-[license-image]: https://img.shields.io/badge/license-apache%20v2-brightgreen.svg
 [Apache License 2.0]: https://github.com/SecurityRAT/SecurityRAT/blob/master/LICENSE
+[license]: http://www.apache.org/licenses/LICENSE-2.0
+[license-image]: https://img.shields.io/badge/license-apache%20v2-brightgreen.svg


### PR DESCRIPTION
This pr creates a new workflow that is run daily: `housekeeper.yaml`
The housekeeper runs a lychee action which checks all the links in the project for `.md` files only
The workflow will fail if there is a broken link, for example to https://securityrat.org/
There was one existing broken link detected, and this has been fixed up to https://www.apache.org/licenses/LICENSE-2.0

closes issue #206 