### PR TITLE
Switch app base image to temurin

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jdk
+FROM eclipse-temurin:11.0.21_9-jdk
 
 ENV COMPRESSEDFILE="securityrat*.tar.gz"
 

--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jdk
 
 ENV COMPRESSEDFILE="securityrat*.tar.gz"
 


### PR DESCRIPTION
The currently used base image is deprecated (https://hub.docker.com/_/openjdk) and a switch to another image is recommended.

I switched the base image to [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin)'s JDK 11 image which is still supported and has the nice side effect of getting rid of a view CVEs.

Using [trivy](https://github.com/aquasecurity/trivy) with the `--vuln-type os` flag:

Output before:
```
securityrat (debian 11.4)

Total: 163 (UNKNOWN: 0, LOW: 74, MEDIUM: 46, HIGH: 37, CRITICAL: 6)
```

Output after:
```
securityrat-temurin (ubuntu 22.04)

Total: 31 (UNKNOWN: 0, LOW: 21, MEDIUM: 10, HIGH: 0, CRITICAL: 0)
```

Not perfect, but it's a start.

Caveat: the image size increases from 492 MB to 656 MB (analyzed using [dive](https://github.com/wagoodman/dive)). There are temurin images that are based on alpine and Red Hat UBI but those would require a few changes to the Dockerfile and a more thorough testing of the application.